### PR TITLE
Fix 1.20.4 error that prevents opening /border gui menu

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.nononitas</groupId>
     <artifactId>PlotBorder</artifactId>
-    <version>1.9.3</version>
+    <version>1.9.4</version>
 
 
     <properties>

--- a/src/main/java/de/nononitas/plotborder/util/Heads.java
+++ b/src/main/java/de/nononitas/plotborder/util/Heads.java
@@ -40,7 +40,7 @@ public enum Heads {
 
         SkullMeta headMeta = (SkullMeta) head.getItemMeta();
 
-        GameProfile profile = new GameProfile(UUID.randomUUID(), null);
+        GameProfile profile = new GameProfile(UUID.randomUUID(), "NotNullNotEmpty");
 
         profile.getProperties().put("textures", new Property("textures", url));
 


### PR DESCRIPTION
Updated GameProfile initializer which requires a non-null non-empty value based on a recent update. An actual value is not necessary, so replaced `null` with `"NotNullNotEmpty"` placeholder string.

This patch should restore compatibility with v1.20.4
Tested in game on paper: git-Paper-446 (MC:1.20.4) GUI now opens, and next button heads still display correctly after change.

Original Error:
```
[00:44:11 ERROR]: null
org.bukkit.command.CommandException: Unhandled exception executing command 'border' in plugin PlotBorder v1.9.3
        at org.bukkit.command.PluginCommand.execute(PluginCommand.java:47) ~[paper-api-1.20.4-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:155) ~[paper-api-1.20.4-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.v1_20_R3.CraftServer.dispatchCommand(CraftServer.java:999) ~[paper-1.20.4.jar:git-Paper-446]
        at org.bukkit.craftbukkit.v1_20_R3.command.BukkitCommandWrapper.run(BukkitCommandWrapper.java:64) ~[paper-1.20.4.jar:git-Paper-446]
        at com.mojang.brigadier.context.ContextChain.runExecutable(ContextChain.java:73) ~[brigadier-1.2.9.jar:?]
        at net.minecraft.commands.execution.tasks.ExecuteCommand.execute(ExecuteCommand.java:32) ~[paper-1.20.4.jar:git-Paper-446]
        at net.minecraft.commands.execution.tasks.ExecuteCommand.execute(ExecuteCommand.java:19) ~[paper-1.20.4.jar:git-Paper-446]
        at net.minecraft.commands.execution.UnboundEntryAction.lambda$bind$0(UnboundEntryAction.java:8) ~[paper-1.20.4.jar:git-Paper-446]
        at net.minecraft.commands.execution.CommandQueueEntry.a(CommandQueueEntry.java:5) ~[paper-1.20.4.jar:git-Paper-446]
        at net.minecraft.commands.execution.ExecutionContext.runCommandQueue(ExecutionContext.java:101) ~[paper-1.20.4.jar:git-Paper-446]
        at net.minecraft.commands.Commands.executeCommandInContext(Commands.java:434) ~[?:?]
        at net.minecraft.commands.Commands.performCommand(Commands.java:336) ~[?:?]
        at net.minecraft.commands.Commands.performCommand(Commands.java:323) ~[?:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.performChatCommand(ServerGamePacketListenerImpl.java:2230) ~[?:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.lambda$handleChatCommand$14(ServerGamePacketListenerImpl.java:2190) ~[?:?]
        at net.minecraft.util.thread.BlockableEventLoop.lambda$submitAsync$0(BlockableEventLoop.java:59) ~[?:?]
        at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?]
        at net.minecraft.server.TickTask.run(TickTask.java:18) ~[paper-1.20.4.jar:git-Paper-446]
        at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:153) ~[?:?]
        at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[?:?]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1455) ~[paper-1.20.4.jar:git-Paper-446]
        at net.minecraft.server.MinecraftServer.d(MinecraftServer.java:194) ~[paper-1.20.4.jar:git-Paper-446]
        at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:126) ~[?:?]
        at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1432) ~[paper-1.20.4.jar:git-Paper-446]
        at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1355) ~[paper-1.20.4.jar:git-Paper-446]
        at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:136) ~[?:?]
        at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1506) ~[paper-1.20.4.jar:git-Paper-446]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1216) ~[paper-1.20.4.jar:git-Paper-446]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:319) ~[paper-1.20.4.jar:git-Paper-446]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: java.lang.ExceptionInInitializerError
        at de.nononitas.plotborder.Gui.openGui(Gui.java:60) ~[PlotBorder-1.9.3.jar:?]
        at de.nononitas.plotborder.PlotBorder.lambda$initCmds$1(PlotBorder.java:137) ~[PlotBorder-1.9.3.jar:?]
        at org.bukkit.command.PluginCommand.execute(PluginCommand.java:45) ~[paper-api-1.20.4-R0.1-SNAPSHOT.jar:?]
        ... 29 more
Caused by: java.lang.NullPointerException: Profile name must not be null
        at java.util.Objects.requireNonNull(Objects.java:233) ~[?:?]
        at com.mojang.authlib.GameProfile.<init>(GameProfile.java:31) ~[authlib-6.0.52.jar:?]
        at de.nononitas.plotborder.util.Heads.createSkull(Heads.java:43) ~[PlotBorder-1.9.3.jar:?]
        at de.nononitas.plotborder.util.Heads.<init>(Heads.java:29) ~[PlotBorder-1.9.3.jar:?]
        at de.nononitas.plotborder.util.Heads.<clinit>(Heads.java:21) ~[PlotBorder-1.9.3.jar:?]
        at de.nononitas.plotborder.Gui.openGui(Gui.java:60) ~[PlotBorder-1.9.3.jar:?]
        at de.nononitas.plotborder.PlotBorder.lambda$initCmds$1(PlotBorder.java:137) ~[PlotBorder-1.9.3.jar:?]
        at org.bukkit.command.PluginCommand.execute(PluginCommand.java:45) ~[paper-api-1.20.4-R0.1-SNAPSHOT.jar:?]
        ... 29 more
```